### PR TITLE
reduce to one line, make sure django is always defined

### DIFF
--- a/django-filters.js
+++ b/django-filters.js
@@ -1,7 +1,4 @@
-if(!window.django) {
-    window.django = {};
-    var django = window.django;
-}
+var django = window.django || (window.django = {});
 
 (function(){
     "use strict";


### PR DESCRIPTION
Adding filters to `django.filters` fails when `window.django` is already defined (errors out on line 6), such as when the [django js18n catalog](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/#using-the-javascript-translation-catalog) is loaded. This update is meant to fix that.
